### PR TITLE
fix: schema layout with gaps does not apply

### DIFF
--- a/reactor/config.lua
+++ b/reactor/config.lua
@@ -97,7 +97,7 @@ local function configInstantiate(cfg)
     local profile = {}
     profile.count = schema.count
     local layout = {}
-    for i, id in ipairs(schema.layout) do
+    for i, id in pairs(schema.layout) do
       layout[i] = instantiateItem(v.item[id])
     end
     profile.layout = layout


### PR DESCRIPTION
When a user schema contains blank grids, items after this grid will not apply to the reactor instance.